### PR TITLE
improvements on the cache resolver

### DIFF
--- a/src/frontend/4s-query.c
+++ b/src/frontend/4s-query.c
@@ -211,6 +211,7 @@ int main(int argc, char *argv[])
     int ret = 0;
 
     fs_query_state *qs = fs_query_init(link, NULL, NULL);
+    qs->verbosity = verbosity;
     fs_query *qr = fs_query_execute(qs, link, bu, query, flags, opt_level, soft_limit);
     if (fs_query_errors(qr)) {
         ret = 1;
@@ -258,6 +259,7 @@ static void programatic_io(fsp_link *link, raptor_uri *bu, const char *query_lan
 
     const int segments = fsp_link_segments(link);
     fs_query_state *qs = fs_query_init(link, NULL, NULL);
+    qs->verbosity = verbosity;
 
     do {
 	pos = query;
@@ -361,6 +363,7 @@ static void interactive(fsp_link *link, raptor_uri *bu, const char *result_forma
     rl_attempted_completion_function = resource_completion;
 
     fs_query_state *qs = fs_query_init(link, NULL, NULL);
+    qs->verbosity = verbosity;
 
     do {
 	/* assemble query string */

--- a/src/frontend/query-cache.c
+++ b/src/frontend/query-cache.c
@@ -207,6 +207,16 @@ int fs_query_cache_flush(fs_query_state *qs, int verbosity)
             }
         }
     }
+    if (verbosity > 0) {
+        printf("# @resolver@ cache_stats hits %u l1 %u l2 %u fails %u (%.4f perc. success)\n",
+            qs->cache_hits,qs->cache_success_l1,qs->cache_success_l2,qs->cache_fail,
+            ((((double)qs->cache_success_l1)+((double)qs->cache_success_l2))/((double)qs->cache_hits))*100.0);
+        printf("# @resolver@ cache_stats items pre cached %u calls %u elapse %.3f\n",
+        qs->pre_cache_total,qs->resolve_all_calls,qs->resolve_all_elapse);
+        printf("# @resolver@ cache_stats resolve single calls %u elapse %.3f\n",
+        qs->cache_fail,qs->resolve_unique_elapse);
+    }
+
     g_static_mutex_unlock(&qs->cache_mutex);
     
     return 0;

--- a/src/frontend/query-intl.h
+++ b/src/frontend/query-intl.h
@@ -23,6 +23,17 @@ struct _fs_query_state {
     /* raptor + rasqal state */
     rasqal_world *rasqal_world;
     raptor_world *raptor_world;
+
+    int verbosity;
+    /* the following cache stats are filled only if verbosity > 0 */
+    unsigned int cache_hits; /* total queries to the cache */
+    unsigned int cache_success_l1; /* number of l1 success hits */
+    unsigned int cache_success_l2;  /* number of l2 success hits */
+    unsigned int cache_fail;  /* number of cache hits with no data on l1 or l2 */
+    unsigned int pre_cache_total; /* number of items pre cached for the query */
+    unsigned int resolve_all_calls; /* total num of resolve_all calls */
+    double resolve_all_elapse;  /* total sum of elapsed time on resolve_all calls */
+    double resolve_unique_elapse; /* total sum of elapsed time on resolve(single rid) calls */
 };
 
 struct _fs_query {
@@ -32,6 +43,7 @@ struct _fs_query {
     fs_binding *bb[FS_MAX_BLOCKS];	/* per block binding table */
     int segments;
     int num_vars;			/* number of projected variables */
+    int num_vars_total;			/* number of total variables */
     int expressions;			/* number of projected expressions */
     int construct;
     int describe;

--- a/src/frontend/query.c
+++ b/src/frontend/query.c
@@ -657,6 +657,10 @@ fs_query *fs_query_execute(fs_query_state *qs, fsp_link *link, raptor_uri *bu, c
 	fs_query_order(q);
     }
 
+    q->num_vars_total = 0; /* total number, not just the ones projected in SELECT */
+    for(int i=1;i<FS_BINDING_MAX_VARS && q->bt[i].name;i++)
+         q->num_vars_total ++;
+
     return q;
 }
 

--- a/src/frontend/results.c
+++ b/src/frontend/results.c
@@ -82,8 +82,11 @@ static int resolve(fs_query *q, fs_rid rid, fs_resource *res)
 
 	return 0;
     }
+
+    q->qs->cache_hits++;
     g_static_mutex_lock(&cache_mutex);
     if (res_l2_cache[rid & CACHE_MASK].rid == rid) {
+        q->qs->cache_success_l2++;
 	memcpy(res, &res_l2_cache[rid & CACHE_MASK], sizeof(fs_resource));
         g_static_mutex_unlock(&cache_mutex);
 
@@ -95,12 +98,19 @@ static int resolve(fs_query *q, fs_rid rid, fs_resource *res)
     }
     gpointer hit;
     if ((hit = g_hash_table_lookup(res_l1_cache, &rid))) {
+        q->qs->cache_success_l1++;
 	memcpy(res, hit, sizeof(fs_resource));
         g_static_mutex_unlock(&cache_mutex);
 
         return 0;
     }
     g_static_mutex_unlock(&cache_mutex);
+
+GTimer *tmr=NULL;
+    if (q->qs->verbosity) {
+        tmr = g_timer_new();
+        q->qs->cache_fail++;
+    }
 
     fs_rid_vector *r = fs_rid_vector_new(1);
     r->data[0] = rid;
@@ -118,6 +128,11 @@ printf("resolving %016llx\n", rid);
     g_hash_table_insert(res_l1_cache, trid, tres);
     g_static_mutex_unlock(&cache_mutex);
     fs_rid_vector_free(r);
+
+    if (q->qs->verbosity) {
+        q->qs->resolve_unique_elapse += g_timer_elapsed(tmr,NULL);
+        g_timer_destroy(tmr);
+    }
 
     return 0;
 }
@@ -750,6 +765,18 @@ static int resolve_precache_all(fsp_link *l, fs_rid_vector *rv[], int segments)
     }
 
     return 0;
+}
+
+static int resolve_precache_all_with_stats(fs_query *q) {
+    GTimer *tmr=NULL;
+    if (q->qs->verbosity) tmr = g_timer_new();
+    int res = resolve_precache_all(q->link, q->pending, q->segments);
+    if (q->qs->verbosity) {
+        q->qs->resolve_all_elapse += g_timer_elapsed(tmr,NULL);
+        q->qs->resolve_all_calls++;
+        g_timer_destroy(tmr);
+    }
+    return res;
 }
 
 static raptor_term *slot_fill_from_rid(fs_query *q, fs_rid rid)
@@ -2060,9 +2087,17 @@ nextrow: ;
         if (q->limit > 0 && q->limit < RESOURCE_LOOKUP_BUFFER) {
             lookup_buffer_size = q->limit * 2;
         }
+
     unsigned int pre_cache_len = 0;
+    if (q->aggregate) {
+        /* in case this is an aggregate we need to cache all of it
+        because next_row has been moved to the last solution
+        TODO: all RIDs are cached in one go */
+        lookup_buffer_size = next_row;
+    }
 	for (int row=q->row; row < q->row + lookup_buffer_size && row < rows; row++) {
-	    for (int col=1; col <= q->num_vars; col++) {
+	    for (int col=1; col <= q->num_vars_total; col++) {
+        if (!q->bt[col].need_val && !q->bt[col].expression) continue;
 		fs_rid rid;
 		if (row < q->bt[col].vals->length) {
                     if (q->ordering) {
@@ -2081,8 +2116,9 @@ nextrow: ;
 	}
         g_static_mutex_unlock(&cache_mutex);
         if (pre_cache_len)
-            resolve_precache_all(q->link, q->pending, q->segments);
-	q->lastrow = q->row + lookup_buffer_size;
+            resolve_precache_all_with_stats(q);
+        q->qs->pre_cache_total += pre_cache_len;
+	    q->lastrow = q->row + lookup_buffer_size;
     }
 
     int row = q->row;


### PR DESCRIPTION
This commit improves usage and traceability use of the resolver cache.
When using 4s-query -vvv there will some traces to see how the resolver cache is used in that query.
There are also some improvements in the use of the RID resolver cache:
    (1) Queries with variables in filter not selected are used in the cache.
    (2) Variables used in aggregates (sum, count, ...) are also used in the cache.
