### PR TITLE
Use rasqal_world_set_warning_level() to lower warning level for rasqal 0.9.26+ (rasqal GIT HEAD)

### DIFF
--- a/src/frontend/query.c
+++ b/src/frontend/query.c
@@ -239,6 +239,10 @@ fs_query_state *fs_query_init(fsp_link *link, rasqal_world *rasworld, raptor_wor
     if (!qs->rasqal_world) {
         fs_error(LOG_ERR, "failed to allocate rasqal world");
     }
+#if RASQAL_VERSION >= 926
+    /* Lower warning level to get only more serious warnings */
+    rasqal_world_set_warning_level(qs->rasqal_world, 25);
+#endif
     if (rasqal_world_open(qs->rasqal_world)) {
         fs_error(LOG_ERR, "failed to intialise rasqal world");
 	fs_query_fini(qs);


### PR DESCRIPTION
This should make the 'select-unused' test pass.  

I can't run the 4suite test suite on my OSX laptop to confirm this since I just get mysterious errors like
4store[69607]: 4s-client.c:306 kb=query_test_dajobe waiting for lock on segment 0 on HOST.local. port 6734

I will release a new rasqal when it's confirmed this does fix it.
