### PR TITLE
Fixed memory leak in fs_metadata opening/closing.

### DIFF
--- a/src/backend/metadata.c
+++ b/src/backend/metadata.c
@@ -258,6 +258,7 @@ void fs_metadata_close(fs_metadata *m)
         g_free(m->entries[e].val);
     }
     free(m->entries);
+    raptor_free_world(m->rw);
     free(m);
 }
 


### PR DESCRIPTION
A raptor_world was being initialised in fs_metadata_open, but wasn't being
freed at cleanup in fs_metadata_close.
