### PR TITLE
Removes 2 compile warnings, makes output of test more robust

### DIFF
--- a/src/admin/admind.c
+++ b/src/admin/admind.c
@@ -640,7 +640,7 @@ static void handle_cmd_get_kb_info(int client_fd, uint16_t datasize)
     }
 
     /* should already have been checked by client */
-    if (!fsa_is_valid_kb_name(kb_name)) {
+    if (!fsa_is_valid_kb_name((const char *)kb_name)) {
         fsa_error(LOG_CRIT, "Invalid kb name received from client");
         send_error_message(client_fd, "kb name invalid");
         free(kb_name);
@@ -691,7 +691,7 @@ static void handle_cmd_delete_kb(int client_fd, uint16_t datasize)
     }
 
     /* should already have been checked by client */
-    if (!fsa_is_valid_kb_name(kb_name)) {
+    if (!fsa_is_valid_kb_name((const char *)kb_name)) {
         fsa_error(LOG_CRIT, "Invalid kb name received from client");
         send_error_message(client_fd, "kb name invalid");
         free(kb_name);

--- a/tests/admin/scripts/list-stores
+++ b/tests/admin/scripts/list-stores
@@ -12,7 +12,7 @@ wait $PID
 
 CMD="$FS_ADMIN --config-file $FS_CONF list-stores"
 
-OUTPUT=`$CMD | perl -ne 'next unless /^(?:4s_admin_test_kb|store_name )/;print'`
+OUTPUT=`$CMD | perl -ne 'next unless /^(?:4s_admin_test_kb|store_name)/;@a=split(/\s+/, $_, 2);printf("%-17s %s", $a[0], $a[1])'`
 EXITSTATUS=${PIPESTATUS[0]}
 
 echo "$OUTPUT"


### PR DESCRIPTION
Added two casts to admind.c to remove compile time warnings.

Set the width of first field of test output to 17 chars, makes test output the
correct result even on hosts which might have very long store names.
