### PR TITLE
patch for queries with UNION on different subjects and FILTER on predicate variable.

### DIFF
--- a/src/backend/query-backend.c
+++ b/src/backend/query-backend.c
@@ -181,15 +181,18 @@ fs_rid_vector **fs_bind(fs_backend *be, fs_segment segment, unsigned int tobind,
 	}
     }
 
+    if (!(tobind & FS_BIND_BY_SUBJECT && fs_rid_vector_length(pv) > 1 && fs_rid_vector_length(sv) > 0 &&
+        (!(fs_rid_vector_length(pv) > 1) || (fs_rid_vector_length(sv) == fs_rid_vector_length(pv))))) {
+        fs_rid_vector_sort(sv);
+        fs_rid_vector_uniq(sv, 0);
+        fs_rid_vector_sort(pv);
+        fs_rid_vector_uniq(pv, 0);
+    }
     fs_rid_vector_sort(mv);
     fs_rid_vector_uniq(mv, 0);
-    fs_rid_vector_sort(sv);
-    fs_rid_vector_uniq(sv, 0);
-    fs_rid_vector_sort(pv);
-    fs_rid_vector_uniq(pv, 0);
     fs_rid_vector_sort(ov);
     fs_rid_vector_uniq(ov, 0);
-    
+
     fs_rid_vector **ret;
     if (cols == 0) {
 	ret = calloc(1, sizeof(fs_rid_vector *));
@@ -368,7 +371,8 @@ fs_error(LOG_INFO, "bind() branch");
 	    }
 	}
     /* query like (_ s p _) */
-    } else if (tobind & FS_BIND_BY_SUBJECT && fs_rid_vector_length(pv) > 0 && fs_rid_vector_length(sv) > 0) {
+    } else if (tobind & FS_BIND_BY_SUBJECT && fs_rid_vector_length(pv) > 0 && fs_rid_vector_length(sv) > 0 
+               && (!(fs_rid_vector_length(pv) > 1) || (fs_rid_vector_length(sv) == fs_rid_vector_length(pv)))) {
 	if (fs_rid_vector_length(pv) == 1) {
 #ifdef DEBUG_BRANCH
 fs_error(LOG_INFO, "bind() branch");


### PR DESCRIPTION
Some details to be able to reproduce the bug that this patch fixes ...

```
 @prefix : <http://bioportal.bioontology.org/data/> .
 @prefix def: <http://bioportal.bioontology.org/metadata/def/> .

:termC def:zzzz "termC zzzz" .
:termD def:yyyy "termD zzzz" . 
```

And the following query that doen't make much sense, it is just to reflect the bug ... 

```
SELECT * WHERE {
    { <http://bioportal.bioontology.org/data/termC> ?p ?o . }
   UNION 
    { <http://bioportal.bioontology.org/data/termF> ?p ?o . }
   FILTER (?p = <http://bioportal.bioontology.org/metadata/def/zzzz> ||
        ?p = <http://bioportal.bioontology.org/metadata/def/yyyy>)
 }
```

This query should return the two triples in the store but returns just one. It seems we  have an issue with query-backend.c that I have fixed.

This patch touches a sensible part of the backend component so it might be good that someone else looks at this carefully. Steve, you might be able to find a better patch by touching the query engine ... I could not find the issue there.

Manuel 
