### PR TITLE
test for $# and $1 in a correct and consistent way

### DIFF
--- a/src/utilities/4s-cluster-create
+++ b/src/utilities/4s-cluster-create
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-if [ $1 == '--help' ] ; then
+if [ "$1" = '--help' ] ; then
   echo "Usage: $0 <kbname> [--password password]"
   exit
 fi
 
-if [ $1 == '--version' ] ; then
+if [ "$1" = '--version' ] ; then
   4s-backend --version | sed 's/4s-backend/'`basename $0`'/'
   exit
 fi

--- a/src/utilities/4s-cluster-destroy
+++ b/src/utilities/4s-cluster-destroy
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-if [ $1 == '--help' ] ; then
+if [ "$1" = '--help' ] ; then
   echo "Usage: $0 <kbname>"
   exit
 fi
 
-if [ $1 == '--version' ] ; then
+if [ "$1" = '--version' ] ; then
   4s-backend --version | sed 's/4s-backend/'`basename $0`'/'
   exit
 fi

--- a/src/utilities/4s-cluster-file-backup
+++ b/src/utilities/4s-cluster-file-backup
@@ -11,18 +11,18 @@
 # NB ensure target directories /var/lib/4store and MySQL DB directory exist
 #
 
-if [ $1 == '--help' ] ; then
+if [ "$1" = '--help' ] ; then
   echo "Usage: $0 <kbname>"
   exit
 fi
 
-if [ $1 == '--version' ] ; then
+if [ "$1" = '--version' ] ; then
   4s-backend --version | sed 's/4s-backend/'`basename $0`'/'
   exit
 fi
 
 SSH="ssh -c blowfish-cbc"
-if [ $# == 0 ] ; then
+if (($# == 0)) ; then
   echo "Usage: $0 <kbname>"
   exit;
 fi;

--- a/src/utilities/4s-cluster-info
+++ b/src/utilities/4s-cluster-info
@@ -5,11 +5,11 @@ function usage {
   echo "       $0 <kbname>";
 }
 
-if [ "x$1" = 'x--help' ] ; then
+if [ "$1" = '--help' ] ; then
   usage
   exit
 fi
-if [ "x$1" = 'x--version' ] ; then
+if [ "$1" = '--version' ] ; then
   4s-backend --version | sed 's/4s-backend/'`basename $0`'/'
   exit
 fi

--- a/src/utilities/4s-cluster-start
+++ b/src/utilities/4s-cluster-start
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-if [[ $1 == '--help' ]] ; then
+if [ "$1" = '--help' ] ; then
   echo "Usage: $0 <kbname>"
   exit
 fi
 
-if [[ $1 == '--version' ]] ; then
+if [ "$1" = '--version' ] ; then
   4s-backend --version | sed 's/4s-backend/'`basename $0`'/'
   exit
 fi

--- a/src/utilities/4s-cluster-stop
+++ b/src/utilities/4s-cluster-stop
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-if [[ $1 == '--help' ]] ; then
+if [ "$1" = '--help' ] ; then
   echo "Usage: $0 <kbname>"
   exit
 fi
 
-if [[ $1 == '--version' ]] ; then
+if [ "$1" = '--version' ] ; then
   4s-backend --version | sed 's/4s-backend/'`basename $0`'/'
   exit
 fi

--- a/src/utilities/4s-file-backup
+++ b/src/utilities/4s-file-backup
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-if [ $1 == '--help' ] ; then
+if [ "$1" = '--help' ] ; then
   echo "Usage: $0 <kbname>"
   exit
 fi
 
-if [ $1 == '--version' ] ; then
+if [ "$1" = '--version' ] ; then
   4s-backend --version | sed 's/4s-backend/'`basename $0`'/'
   exit
 fi

--- a/src/utilities/4s-ssh-all
+++ b/src/utilities/4s-ssh-all
@@ -1,16 +1,16 @@
 #!/bin/sh
 
-if [ "$1" == '--help' ] ; then
+if [ "$1" = '--help' ] ; then
   echo "Usage: $0 <remote command>"
   exit
 fi
 
-if [ "$1" == '--version' ] ; then
+if [ "$1" = '--version' ] ; then
   4s-backend --version | sed 's/4s-backend/'`basename $0`'/'
   exit
 fi
 
-if [ $# == 0 ] ; then
+if (($# == 0)) ; then
   echo "Usage: 4s-ssh-all <remote command>"
   echo "remember to quote shell metacharacters"
   exit;

--- a/src/utilities/4s-ssh-all-parallel
+++ b/src/utilities/4s-ssh-all-parallel
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-if [ $1 == '--help' ] ; then
+if [ "$1" = '--help' ] ; then
   echo "Usage: $0 <remote command>"
   exit
 fi
 
-if [ $1 == '--version' ] ; then
+if [ "$1" = '--version' ] ; then
   4s-backend --version | sed 's/4s-backend/'`basename $0`'/'
   exit
 fi
 
-if [ $# == 0 ] ; then
+if (($# == 0)) ; then
   echo "Usage: 4s-ssh-all-parallel <remote command>"
   echo "remember to quote shell metacharacters"
   exit;


### PR DESCRIPTION
I hit some problems like

$ 4s-cluster-create 
/usr/bin/4s-cluster-create: line 3: [: ==: unary operator expected
/usr/bin/4s-cluster-create: line 8: [: ==: unary operator expected

So I reviewed the sources and reworked the scripts so they test for $# and $1 in a consistent and correct way.
