### PR TITLE
Small fix to fix UUID problem during make

### DIFF
--- a/src/http/Makefile.am
+++ b/src/http/Makefile.am
@@ -9,4 +9,4 @@ AM_CFLAGS = -std=gnu99 -Wall $(PROFILE) -g -O2 -I./ -I../ -DGIT_REV=@GIT_REV@ @R
 LIBS = $(PROFILE) @RASQAL_LIBS@ @RAPTOR_LIBS@ @GLIB_LIBS@ @LIBXML_LIBS@ @GTHREAD_LIBS@ @MDNS_LIBS@ `pcre-config --libs`
 
 4s_httpd_SOURCES = httpd.c ../common/gnu-options.c
-4s_httpd_LDADD = ../common/lib4sintl.a $(FRONTEND) ../common/libsort.a ../libs/stemmer/libstemmer.a ../libs/double-metaphone/libdouble_metaphone.a ../libs/mt19937-64/libmt64.a
+4s_httpd_LDADD = ../common/lib4sintl.a $(FRONTEND) ../common/libsort.a ../libs/stemmer/libstemmer.a ../libs/double-metaphone/libdouble_metaphone.a ../libs/mt19937-64/libmt64.a @UUID_LIBS@ 


### PR DESCRIPTION
On Ubuntu 12.04 (and probably others), make fails with "undefined reference to `uuid_generate'" errors while in src/http. Checking the make log, it appears that the -luuid argument was not included in the libtool steps when in this directory. Adding the @UUID_LIBS@ arguments to the LDADD steps in http/Makefile.am seems to set things straight.

Logs are available at https://gist.github.com/2947735
