### PR TITLE
Avoid using pwrite with mmap (or use msync)

### DIFF
--- a/src/backend/ptree.c
+++ b/src/backend/ptree.c
@@ -255,6 +255,8 @@ int fs_ptree_grow_nodes(fs_ptree *pt)
 
     /* need to copy this value as were about to unmap */
     off_t alloc = pt->header->alloc;
+    if (msync(pt->ptr, pt->file_length, MS_SYNC))
+        fs_error(LOG_ERR, "msync failed, ptree might be inconsistent");
     munmap(pt->ptr, pt->file_length);
     pt->file_length = sizeof(struct ptree_header) + alloc;
     if (pwrite(pt->fd, &junk, 1, pt->file_length) == -1) {
@@ -277,11 +279,12 @@ int fs_ptree_grow_leaves(fs_ptree *pt)
 
     /* need to copy this value as were about to unmap */
     off_t alloc = pt->header->alloc;
+    if (msync(pt->ptr, pt->file_length, MS_SYNC))
+        fs_error(LOG_ERR, "msync failed, ptree might be inconsistent");
     munmap(pt->ptr, pt->file_length);
     pt->file_length = sizeof(struct ptree_header) + alloc;
     if (pwrite(pt->fd, &junk, 1, pt->file_length) == -1) {
         fs_error(LOG_ERR, "failed to grow ptree file");
-
         return 1;
     }
     map_file(pt);


### PR DESCRIPTION
Using pwrite and mmap together is not guaranteed by POSIX to produce
consistent results unless you call msync() a lot, which is terribly
slow in most situations, as it waits for a full flush to permanent
storage.

For rhash, this patch converts the pwrite calls to use mmap I/O. For
ptree, it uses msync(), as ptree only calls pwrite when the file
is currently unmapped (so only an msync before munmap should be
necessary)

This fixes up a few more tests that were failing on OpenBSD, yay.
Most of the fails that are left now are just un-ordered queries that return
their results in a different order than they do on Linux (as quads seem
to end up in different segments).
