### PR TITLE
Detect endian/bitness correctly on OpenBSD and others

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -184,6 +184,9 @@ AC_SUBST(GIT_REV)
 # Checks for header files.
 AC_FUNC_ALLOCA
 AC_CHECK_HEADERS([fcntl.h limits.h locale.h netdb.h stddef.h stdint.h stdlib.h string.h sys/file.h sys/mount.h sys/param.h sys/socket.h sys/time.h sys/vfs.h syslog.h unistd.h])
+AC_CHECK_HEADER(machine/endian.h,AC_DEFINE([HAVE_MACHINE_ENDIAN_H], 1, [Defined if machine/endian.h exists]))
+AC_CHECK_HEADER(sys/endian.h,AC_DEFINE([HAVE_SYS_ENDIAN_H], 1, [Defined if sys/endian.h exists]))
+AC_CHECK_HEADER(endian.h,AC_DEFINE([HAVE_ENDIAN_H], 1, [Defined if endian.h exists]))
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_HEADER_STDBOOL

--- a/src/common/umac.c
+++ b/src/common/umac.c
@@ -83,10 +83,22 @@
 /* ---------------------------------------------------------------------- */
 
 #include "../common/umac.h"
+#include "4store-config.h"
 
 #include <string.h>
 #include <stdlib.h>
 #include <stddef.h>
+#include <sys/types.h>
+#if defined(HAVE_MACHINE_ENDIAN_H)
+# include <machine/endian.h>
+#endif
+#if defined(HAVE_SYS_ENDIAN_H)
+# include <sys/endian.h>
+#endif
+#if defined(HAVE_ENDIAN_H)
+# include <endian.h>
+#endif
+
 #if GLADMAN_AES
 #include "aes.h"
 #else
@@ -103,7 +115,7 @@ typedef unsigned short     UINT16; /* 2 byte   */
 typedef unsigned int       UINT32; /* 4 byte   */
 typedef unsigned long long UINT64; /* 8 bytes  */
 
-#if __WORDSIZE == 64
+#if __WORDSIZE == 64 || defined(__LP64__)
 typedef UINT64 UWORD;
 #else
 typedef UINT32 UWORD;
@@ -126,7 +138,7 @@ typedef UINT32 UWORD;
 /* be set true if the host computer is little-endian.                     */
 
 #ifndef __LITTLE_ENDIAN__
-#if __i386__ || __alpha__ || _M_IX86 || __LITTLE_ENDIAN
+#if _M_IX86 || __BYTE_ORDER == __LITTLE_ENDIAN || _BYTE_ORDER == _LITTLE_ENDIAN
 #define __LITTLE_ENDIAN__ 1
 #else
 #define __LITTLE_ENDIAN__ 0


### PR DESCRIPTION
Adds configure tests to look for relevant endian.h headers
on each platform, now checks the BSD-style _BYTE_ORDER as
well as __BYTE_ORDER. Also checks __LP64__ for 64-bitness,
which should work on anything using GCC.

This fixes almost all the tests on OpenBSD now, just a few tiny 
silly things left with libm's rounding being different and so forth.

I've only tried this on x86 and x86_64 so far, but gcc -E on a sparc64
(both Linux and OpenBSD) tells me it should work correctly there too.
Haven't actually tried a sparc build yet, but I might later. I think we
have some Itanium in the DC that's been out of commission for a
few years, but it probably still works. Might try it later just for kicks.
Am I crazy?
