### PR TITLE
Improve the test query HTML UI

### DIFF
--- a/src/http/httpd.c
+++ b/src/http/httpd.c
@@ -1063,6 +1063,11 @@ static void http_query_widget(client_ctxt *ctxt)
    "\nSELECT * WHERE {\n ?s ?p ?o\n} LIMIT 10\n"
    "</textarea><br>\n"
    "<em>Soft limit</em> <input type=\"text\" name=\"soft-limit\">\n"
+   "<select name=\"output\">\n"
+   "<option>xml</option>\n"   
+   "<option>json</option>\n"
+   "<option>text</option>\n"
+   "</select>\n"
    "<input type=\"submit\" value=\"Execute\"><input type=\"reset\">\n"
    "</form>\n");
 


### PR DESCRIPTION
For new comers to linked data, 4-store is a great way to start.

Unfortunately, rendering out xml vs the browser behaviour of downloading attachments is frustrating.

There's a bug in dealing with the POST params which seems to make this fail, however altering the form to GET displays the correct behaviour
