### PR TITLE
fix httpd's handling of POST to /update/ for striping encoding info from the content type correctly

### DIFF
--- a/src/http/httpd.c
+++ b/src/http/httpd.c
@@ -1297,12 +1297,14 @@ static void http_post_request(client_ctxt *ctxt, gchar *url, gchar *protocol)
     g_free(form);
 
   } else if (!strcmp(url, "/update/")) {
-    const char *form_type = g_hash_table_lookup(ctxt->headers, "content-type");
+    char *form_type = just_content_type(ctxt);
     if (!form_type || strcasecmp(form_type, "application/x-www-form-urlencoded")) {
       http_error(ctxt, "400 4store only implements application/x-www-form-urlencoded");
       http_close(ctxt);
+      g_free(form_type);
       return;
     }
+    g_free(form_type);
 
     const char *length = g_hash_table_lookup(ctxt->headers, "content-length");
     ctxt->bytes_left = length ? atol(length) : 0;


### PR DESCRIPTION
The problem is well described here: https://groups.google.com/forum/#!msg/4store-support/cWgNKRedxlk/tW2Vtg6VyLkJ -- but Oliver's patch is not the right one. Neither of Steve. I hope to fix it correctly.
