### PR TITLE
let user change store root at runtime

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,13 +20,13 @@ if test "X$PKG_CONFIG" = X; then
 	AC_MSG_ERROR([Cannot find pkg-config, you need this to build])
 fi
 
-AC_ARG_WITH([storage_path],
-	[AS_HELP_STRING([--with-storage-path=PATH],
-	                [set directory used to store indexes default=/var/lib/4store])],
+AC_ARG_WITH([default_storage_path],
+	[AS_HELP_STRING([--with-default-storage-path=PATH],
+	                [set default directory used to store indexes default=/var/lib/4store])],
 	[],
 	[with_storage_path=/var/lib/4store])
-FS_STORE_ROOT="$with_storage_path"
-AC_SUBST(FS_STORE_ROOT)
+FS_DEFAULT_STORE_ROOT="$with_default_storage_path"
+AC_SUBST(FS_DEFAULT_STORE_ROOT)
 
 AC_ARG_WITH([config_file],
 	[AS_HELP_STRING([--with-config-file=PATH],

--- a/src/admin/admin_backend.c
+++ b/src/admin/admin_backend.c
@@ -33,6 +33,7 @@
 #include <sys/stat.h>
 
 #include "../common/params.h"
+#include "../common/4s-store-root.h"
 #include "../common/error.h"
 #include "../backend/metadata.h"
 
@@ -65,7 +66,7 @@ int fsab_kb_info_init(fsa_kb_info *ki, const unsigned char *kb_name, int *err)
     ki->name = (unsigned char *)strdup((char *)kb_name);
 
     /* check if kb exists */
-    len = (strlen(FS_KB_DIR)-2) + strlen((char *)kb_name) + 1;
+    len = (strlen(fs_get_kb_dir_format())-2) + strlen((char *)kb_name) + 1;
     path = (char *)malloc(len * sizeof(char));
     if (path == NULL) {
         errno = ENOMEM;
@@ -74,7 +75,7 @@ int fsab_kb_info_init(fsa_kb_info *ki, const unsigned char *kb_name, int *err)
     }
 
     /* generate full path to kb dir */
-    rv = sprintf(path, FS_KB_DIR, kb_name);
+    rv = sprintf(path, fs_get_kb_dir_format(), kb_name);
     if (rv < 0) {
         *err = ADM_ERR_GENERIC;
         fsa_error(LOG_DEBUG, "sprintf failed");
@@ -100,7 +101,7 @@ int fsab_kb_info_init(fsa_kb_info *ki, const unsigned char *kb_name, int *err)
     }
 
     /* alloc mem for string path to runtime.info */
-    len = (strlen(FS_RI_FILE)-2) + strlen((char *)kb_name) + 1;
+    len = (strlen(fs_get_ri_file_format())-2) + strlen((char *)kb_name) + 1;
     path = (char *)malloc(len * sizeof(char));
     if (path == NULL) {
         errno = ENOMEM;
@@ -109,7 +110,7 @@ int fsab_kb_info_init(fsa_kb_info *ki, const unsigned char *kb_name, int *err)
     }
 
     /* generate full path to runtime.info */
-    rv = sprintf(path, FS_RI_FILE, kb_name);
+    rv = sprintf(path, fs_get_ri_file_format(), kb_name);
     if (rv < 0) {
         *err = ADM_ERR_GENERIC;
         fsa_error(LOG_DEBUG, "sprintf failed");
@@ -233,10 +234,10 @@ fsa_kb_info *fsab_get_local_kb_info_all(int *err)
     fsa_kb_info *cur_ki = NULL;
     int rv;
 
-    dp = opendir(FS_STORE_ROOT);
+    dp = opendir(fs_get_store_root());
     if (dp == NULL) {
         fsa_error(LOG_ERR, "failed to open directory '%s': %s",
-                  FS_STORE_ROOT, strerror(errno));
+                  fs_get_store_root(), strerror(errno));
         *err = ADM_ERR_GENERIC;
         return NULL;
     }

--- a/src/backend/backend.c
+++ b/src/backend/backend.c
@@ -31,6 +31,7 @@
 #include "../common/uuid.h"
 #include "../common/error.h"
 #include "../common/params.h"
+#include "../common/4s-store-root.h"
 #include "../common/timing.h"
 #include "backend.h"
 #include "import-backend.h"
@@ -703,7 +704,11 @@ int fs_backend_unlink_indexes(fs_backend *be, fs_segment seg)
     }
 
     /* TODO remove TList support or cleaner impl. here */
-    char *command = g_strdup_printf("rm -f "FS_TLIST_ALL, be->db_name, be->segment);
+    gchar *command_format = g_strconcat("rm -f ",
+					fs_get_tlist_all_format(),
+					NULL);
+    char *command = g_strdup_printf(command_format, be->db_name, be->segment);
+    g_free(command_format);
     system(command);
     g_free(command);
 

--- a/src/backend/chain.c
+++ b/src/backend/chain.c
@@ -33,13 +33,14 @@
 #include "bucket.h"
 #include "chain.h"
 #include "../common/params.h"
+#include "../common/4s-store-root.h"
 #include "../common/error.h"
 
 #define CHAIN_ID 0x4a584230
 
 static char *fname_from_label(fs_backend *be, const char *label)
 {
-    return g_strdup_printf(FS_CHAIN, fs_backend_get_kb(be), fs_backend_get_segment(be), label);
+  return g_strdup_printf(fs_get_chain_format(), fs_backend_get_kb(be), fs_backend_get_segment(be), label);
 }
 
 static int unmap_bc(fs_chain *bc)

--- a/src/backend/disk-space.c
+++ b/src/backend/disk-space.c
@@ -30,13 +30,14 @@
 
 #include "../common/error.h"
 #include "../common/params.h"
+#include "../common/4s-store-root.h"
 
 /* returns the free disk space (in GB) remaining in the filesystem used by the
  * storage system */
 float fs_free_disk_gb(const char *kb)
 {
     struct statfs buf;
-    char *mdfn = g_strdup_printf(FS_MD_FILE, kb);
+    char *mdfn = g_strdup_printf(fs_get_md_file_format(), kb);
 
     if (statfs(mdfn, &buf) == -1) {
         fs_error(LOG_ERR, "cannot statfs('%s'): %s", mdfn, strerror(errno));
@@ -54,7 +55,7 @@ float fs_free_disk_gb(const char *kb)
 float fs_free_disk(const char *kb)
 {
     struct statfs buf;
-    char *mdfn = g_strdup_printf(FS_MD_FILE, kb);
+    char *mdfn = g_strdup_printf(fs_get_md_file_format(), kb);
 
     if (statfs(mdfn, &buf) == -1) {
         fs_error(LOG_ERR, "cannot statfs('%s'): %s", mdfn, strerror(errno));

--- a/src/backend/list.c
+++ b/src/backend/list.c
@@ -32,6 +32,7 @@
 #include "lock.h"
 #include "../common/error.h"
 #include "../common/timing.h"
+#include "../common/4s-store-root.h"
 
 #define LIST_BUFFER_SIZE 256
 
@@ -63,7 +64,7 @@ struct _fs_list {
 
 fs_list *fs_list_open(fs_backend *be, const char *label, size_t width, int flags)
 {
-    char *filename = g_strdup_printf(FS_LIST, fs_backend_get_kb(be), fs_backend_get_segment(be), label);
+  char *filename = g_strdup_printf(fs_get_list_format(), fs_backend_get_kb(be), fs_backend_get_segment(be), label);
     fs_list *l = fs_list_open_filename(filename, width, flags);
     g_free(filename);
 

--- a/src/backend/lock.c
+++ b/src/backend/lock.c
@@ -28,10 +28,11 @@
 
 #include "lock.h"
 #include "../common/error.h"
+#include "../common/4s-store-root.h"
 
 int fs_lock_kb(const char *kb)
 {
-    char *fn = g_strdup_printf(FS_MD_FILE, kb);
+    char *fn = g_strdup_printf(fs_get_md_file_format(), kb);
     int fd = open(fn, FS_O_NOATIME | O_RDONLY | O_CREAT, 0600);
     if (fd == -1) {
         fs_error(LOG_CRIT, "failed to open metadata file %s for locking: %s",
@@ -56,7 +57,7 @@ int fs_lock_kb(const char *kb)
 
 int fs_lock(fs_backend *be, const char *name, fs_lock_action action, int block)
 {
-    char *fn = g_strdup_printf(FS_FILE_LOCK, fs_backend_get_kb(be), fs_backend_get_segment(be), name);
+    char *fn = g_strdup_printf(fs_get_file_lock_format(), fs_backend_get_kb(be), fs_backend_get_segment(be), name);
     int ret = -1;
     int fd;
 
@@ -99,7 +100,7 @@ int fs_lock(fs_backend *be, const char *name, fs_lock_action action, int block)
 int fs_lock_taken(fs_backend *be, const char *name)
 {
     struct stat junk;
-    char *fn = g_strdup_printf(FS_FILE_LOCK, fs_backend_get_kb(be), fs_backend_get_segment(be), name);
+    char *fn = g_strdup_printf(fs_get_file_lock_format(), fs_backend_get_kb(be), fs_backend_get_segment(be), name);
     int ret = stat(fn, &junk);
     g_free(fn);
     if (ret == -1 && errno == ENOENT) {

--- a/src/backend/metadata.c
+++ b/src/backend/metadata.c
@@ -28,6 +28,7 @@
 #include <syslog.h>
 
 #include "../common/params.h"
+#include "../common/4s-store-root.h"
 #include "../common/error.h"
 #include "metadata.h"
 
@@ -62,10 +63,15 @@ static void parse_stmt(void *user_data, raptor_statement *statement)
 fs_metadata *fs_metadata_open(const char *kb)
 {
     fs_metadata *m = calloc(1, sizeof(fs_metadata));
+    gchar *fs_md_file_uri_format;
+    fs_md_file_uri_format = g_strconcat("file://",
+					fs_get_md_file_format(),
+					NULL);
     m->size = 16;
     m->length = 0;
     m->entries = calloc(m->size, sizeof(struct m_entry));
-    m->uri = g_strdup_printf("file://"FS_MD_FILE, kb);
+    m->uri = g_strdup_printf(fs_md_file_uri_format, kb);
+    g_free(fs_md_file_uri_format);
 
     int fd;
     if ((fd = open(m->uri + 7, FS_O_NOATIME | O_CREAT, FS_FILE_MODE)) == -1) {

--- a/src/backend/mhash.c
+++ b/src/backend/mhash.c
@@ -31,6 +31,7 @@
 #include "mhash.h"
 #include "tbchain.h"
 #include "../common/params.h"
+#include "../common/4s-store-root.h"
 #include "../common/error.h"
 
 #define FS_MHASH_DEFAULT_LENGTH         4096
@@ -72,7 +73,7 @@ static int fs_mhash_write_header(fs_mhash *mh);
 
 fs_mhash *fs_mhash_open(fs_backend *be, const char *label, int flags)
 {
-    char *filename = g_strdup_printf(FS_MHASH, fs_backend_get_kb(be),
+    char *filename = g_strdup_printf(fs_get_mhash_format(), fs_backend_get_kb(be),
                                      fs_backend_get_segment(be), label);
     fs_mhash *mh = fs_mhash_open_filename(filename, flags);
     g_free(filename);

--- a/src/backend/ptable.c
+++ b/src/backend/ptable.c
@@ -32,6 +32,7 @@
 #include "backend.h"
 #include "ptable.h"
 #include "../common/params.h"
+#include "../common/4s-store-root.h"
 #include "../common/error.h"
 
 #define PTABLE_ID 0x4a585430 /* JXT0 */
@@ -64,7 +65,7 @@ struct _fs_ptable {
 
 static char *fname_from_label(fs_backend *be, const char *label)
 {
-    return g_strdup_printf(FS_PTABLE, fs_backend_get_kb(be), fs_backend_get_segment(be), label);
+    return g_strdup_printf(fs_get_ptable_format(), fs_backend_get_kb(be), fs_backend_get_segment(be), label);
 }
 
 static int unmap_pt(fs_ptable *pt)

--- a/src/backend/ptree.c
+++ b/src/backend/ptree.c
@@ -33,6 +33,7 @@
 #include "../common/4s-datatypes.h"
 #include "../common/4s-hash.h"
 #include "../common/params.h"
+#include "../common/4s-store-root.h"
 #include "../common/error.h"
 
 #define FS_PTREE_ID 0x4a585031
@@ -120,7 +121,7 @@ int fs_ptree_grow_leaves(fs_ptree *pt);
 
 fs_ptree *fs_ptree_open(fs_backend *be, fs_rid pred, char pk, int flags, fs_ptable *chain)
 {
-    char *filename = g_strdup_printf(FS_PTREE, fs_backend_get_kb(be),
+    char *filename = g_strdup_printf(fs_get_ptree_format(), fs_backend_get_kb(be),
                                      fs_backend_get_segment(be), pk, pred);
     fs_ptree *pt = fs_ptree_open_filename(filename, flags, chain);
     g_free(filename);

--- a/src/backend/rhash.c
+++ b/src/backend/rhash.c
@@ -34,6 +34,7 @@
 #include "list.h"
 #include "prefix-trie.h"
 #include "../common/4s-hash.h"
+#include "../common/4s-store-root.h"
 #include "../common/params.h"
 #include "../common/error.h"
 
@@ -126,7 +127,7 @@ static char *uncompress_bcdate(unsigned char *bcd);
 
 fs_rhash *fs_rhash_open(fs_backend *be, const char *label, int flags)
 {
-    char *filename = g_strdup_printf(FS_RHASH, fs_backend_get_kb(be),
+    char *filename = g_strdup_printf(fs_get_rhash_format(), fs_backend_get_kb(be),
                                      fs_backend_get_segment(be), label);
     fs_rhash *rh = fs_rhash_open_filename(filename, flags);
     g_free(filename);

--- a/src/backend/tbchain.c
+++ b/src/backend/tbchain.c
@@ -31,6 +31,7 @@
 #include "tbchain.h"
 #include "ptree.h"
 #include "../common/params.h"
+#include "../common/4s-store-root.h"
 #include "../common/error.h"
 #include "../common/timing.h"
 
@@ -92,7 +93,7 @@ static fs_index_node fs_tbchain_new_block(fs_tbchain *bc);
 
 static char *fname_from_label(fs_backend *be, const char *label)
 {
-    return g_strdup_printf(FS_TBCHAIN, fs_backend_get_kb(be), fs_backend_get_segment(be), label);
+    return g_strdup_printf(fs_get_tbchain_format(), fs_backend_get_kb(be), fs_backend_get_segment(be), label);
 }
 
 static int unmap_bc(fs_tbchain *bc)

--- a/src/backend/tlist.c
+++ b/src/backend/tlist.c
@@ -32,6 +32,7 @@
 #include "lock.h"
 #include "../common/error.h"
 #include "../common/timing.h"
+#include "../common/4s-store-root.h"
 
 #define LIST_BUFFER_SIZE 256
 
@@ -79,20 +80,20 @@ fs_tlist *fs_tlist_open(fs_backend *be, fs_rid model, int flags)
         char hash[17];
         sprintf(hash, "%016llx", model);
         hash[16] = '\0';
-        char *dirname = g_strdup_printf(FS_TLIST_DIRD, fs_backend_get_kb(be),
+        char *dirname = g_strdup_printf(fs_get_tlist_dird_format(), fs_backend_get_kb(be),
                                         fs_backend_get_segment(be), hash[0],
                                         hash[1], hash[2], hash[3]);
         struct stat buf;
         int ret = stat(dirname, &buf);
         if (ret) mkdir(dirname, FS_FILE_MODE + 0100);
-        char *filename = g_strdup_printf(FS_TLIST_DIR, fs_backend_get_kb(be),
+        char *filename = g_strdup_printf(fs_get_tlist_dir_format(), fs_backend_get_kb(be),
                                          fs_backend_get_segment(be),
                                          hash[0], hash[1],
                                          hash[2], hash[3], hash+4);
         l = fs_tlist_open_filename(filename, flags);
         g_free(filename);
     } else {
-        char *filename = g_strdup_printf(FS_TLIST, fs_backend_get_kb(be),
+	char *filename = g_strdup_printf(fs_get_tlist_format(), fs_backend_get_kb(be),
                                          fs_backend_get_segment(be), model);
         l = fs_tlist_open_filename(filename, flags);
         g_free(filename);

--- a/src/backend/tree.c
+++ b/src/backend/tree.c
@@ -32,6 +32,7 @@
 #include "backend.h"
 #include "tree.h"
 #include "../common/params.h"
+#include "../common/4s-store-root.h"
 #include "../common/error.h"
 
 #include "tree-intl.h"
@@ -142,7 +143,7 @@ void fs_tree_print(fs_tree *t, FILE *out, int verbosity)
 
 fs_tree *fs_tree_open(fs_backend *be, const char *name, int flags)
 {
-    char *file = g_strdup_printf(FS_TREE, fs_backend_get_kb(be), fs_backend_get_segment(be), name);
+    char *file = g_strdup_printf(fs_get_tree_format(), fs_backend_get_kb(be), fs_backend_get_segment(be), name);
     fs_tree *t = fs_tree_open_filename(be, name, file, flags);
 
     return t;

--- a/src/common/4s-server.c
+++ b/src/common/4s-server.c
@@ -23,6 +23,7 @@
 #include "4s-internals.h"
 #include "error.h"
 #include "params.h"
+#include "4s-store-root.h"
 
 #include <errno.h>
 #include <stdlib.h>
@@ -365,7 +366,7 @@ static int init_runtime_info(const char *kb_name, const char *cport)
     struct flock ri_lock;
 
     /* alloc mem for string path to runtime.info */
-    len = (strlen(FS_RI_FILE)-2) + strlen(kb_name) + 1;
+    len = (strlen(fs_get_ri_file_format())-2) + strlen(kb_name) + 1;
     path = (char *)malloc(len * sizeof(char));
     if (path == NULL) {
         kb_error(LOG_CRIT, "failed to malloc %d bytes", len);
@@ -373,7 +374,7 @@ static int init_runtime_info(const char *kb_name, const char *cport)
     }
 
     /* generate full path to runtime.info */
-    rv = sprintf(path, FS_RI_FILE, kb_name);
+    rv = sprintf(path, fs_get_ri_file_format(), kb_name);
     if (rv < 0) {
         kb_error(LOG_ERR, "sprintf failed to write %d bytes", len);
         free(path);

--- a/src/common/4s-store-root.c
+++ b/src/common/4s-store-root.c
@@ -1,0 +1,52 @@
+#include <stdlib.h>
+#include <string.h>
+#include "common/4s-store-root.h"
+#include "common/params.h"
+
+const gchar * fs_get_store_root(void)
+{
+    static gchar * _fs_store_root = NULL;
+    const char *env_setting;
+    if(NULL == _fs_store_root) {
+	env_setting = getenv(FS_STORE_ROOT_ENV_VAR);
+	if(env_setting) {
+	    _fs_store_root = g_strdup((const gchar *)env_setting);
+	} else {
+	    _fs_store_root = strdup((const gchar *)FS_DEFAULT_STORE_ROOT);
+	}
+    }
+    return _fs_store_root;
+}
+
+#define SINGLETON_STRING_GET_FUNCTION(lower_stem,UPPER_STEM)		\
+    const gchar *fs_get_ ## lower_stem (void)				\
+    {									\
+	static gchar *_fs_ ## lower_stem = NULL;			\
+	    if(NULL == _fs_ ## lower_stem) {				\
+		_fs_ ## lower_stem = g_strconcat(fs_get_store_root(),	\
+						 _FS_ ## UPPER_STEM,	\
+						 NULL);			\
+	    }								\
+	    return _fs_ ## lower_stem;					\
+    }
+
+SINGLETON_STRING_GET_FUNCTION(kb_dir_format,     KB_DIR_FORMAT)
+SINGLETON_STRING_GET_FUNCTION(chain_format,      CHAIN_FORMAT)
+SINGLETON_STRING_GET_FUNCTION(file_lock_format,  FILE_LOCK_FORMAT)
+SINGLETON_STRING_GET_FUNCTION(lex_format,        LEX_FORMAT)
+SINGLETON_STRING_GET_FUNCTION(list_format,       LIST_FORMAT)
+SINGLETON_STRING_GET_FUNCTION(md_file_format,    MD_FILE_FORMAT)
+SINGLETON_STRING_GET_FUNCTION(mhash_format,      MHASH_FORMAT)
+SINGLETON_STRING_GET_FUNCTION(ptable_format,     PTABLE_FORMAT)
+SINGLETON_STRING_GET_FUNCTION(ptree_format,      PTREE_FORMAT)
+SINGLETON_STRING_GET_FUNCTION(qlist_format,      QLIST_FORMAT)
+SINGLETON_STRING_GET_FUNCTION(rhash_format,      RHASH_FORMAT)
+SINGLETON_STRING_GET_FUNCTION(ri_file_format,    RI_FILE_FORMAT)
+SINGLETON_STRING_GET_FUNCTION(seg_dir_format,    SEG_DIR_FORMAT)
+SINGLETON_STRING_GET_FUNCTION(slist_format,      SLIST_FORMAT)
+SINGLETON_STRING_GET_FUNCTION(tbchain_format,    TBCHAIN_FORMAT)
+SINGLETON_STRING_GET_FUNCTION(tlist_all_format,  TLIST_ALL_FORMAT)
+SINGLETON_STRING_GET_FUNCTION(tlist_dir_format,  TLIST_DIR_FORMAT)
+SINGLETON_STRING_GET_FUNCTION(tlist_dird_format, TLIST_DIRD_FORMAT)
+SINGLETON_STRING_GET_FUNCTION(tlist_format,      TLIST_FORMAT)
+SINGLETON_STRING_GET_FUNCTION(tree_format,       TREE_FORMAT)

--- a/src/common/4s-store-root.h
+++ b/src/common/4s-store-root.h
@@ -1,0 +1,53 @@
+#ifndef _4S_STORE_ROOT_H
+#define _4S_STORE_ROOT_H
+
+#include <glib.h>
+
+const gchar * fs_get_store_root(void);
+
+#define SINGLETON_STRING_PROTOTYPE(lower_stem)	\
+  const gchar *fs_get_ ## lower_stem (void);
+
+SINGLETON_STRING_PROTOTYPE(kb_dir_format)
+SINGLETON_STRING_PROTOTYPE(chain_format)
+SINGLETON_STRING_PROTOTYPE(file_lock_format)
+SINGLETON_STRING_PROTOTYPE(lex_format)
+SINGLETON_STRING_PROTOTYPE(list_format)
+SINGLETON_STRING_PROTOTYPE(md_file_format)
+SINGLETON_STRING_PROTOTYPE(mhash_format)
+SINGLETON_STRING_PROTOTYPE(ptable_format)
+SINGLETON_STRING_PROTOTYPE(ptree_format)
+SINGLETON_STRING_PROTOTYPE(qlist_format)
+SINGLETON_STRING_PROTOTYPE(rhash_format)
+SINGLETON_STRING_PROTOTYPE(ri_file_format)
+SINGLETON_STRING_PROTOTYPE(seg_dir_format)
+SINGLETON_STRING_PROTOTYPE(slist_format)
+SINGLETON_STRING_PROTOTYPE(tbchain_format)
+SINGLETON_STRING_PROTOTYPE(tlist_all_format)
+SINGLETON_STRING_PROTOTYPE(tlist_dir_format)
+SINGLETON_STRING_PROTOTYPE(tlist_dird_format)
+SINGLETON_STRING_PROTOTYPE(tlist_format)
+SINGLETON_STRING_PROTOTYPE(tree_format)
+
+#define _FS_KB_DIR_FORMAT       "/%s/"
+#define _FS_CHAIN_FORMAT        "/%s/%04x/%s.chain"
+#define _FS_FILE_LOCK_FORMAT    "/%s/%04x/%s.lock"
+#define _FS_LEX_FORMAT          "/%s/%04x/lex.dat"
+#define _FS_LIST_FORMAT         "/%s/%04x/%s.list"
+#define _FS_MD_FILE_FORMAT      "/%s/metadata.nt"
+#define _FS_MHASH_FORMAT        "/%s/%04x/%s.mhash"
+#define _FS_PTABLE_FORMAT       "/%s/%04x/%s.ptable"
+#define _FS_PTREE_FORMAT        "/%s/%04x/p%c-%016llx.ptree"
+#define _FS_QLIST_FORMAT        "/%s/%04x/%s.qlist"
+#define _FS_RHASH_FORMAT        "/%s/%04x/%s.rhash"
+#define _FS_RI_FILE_FORMAT      "/%s/runtime.info"
+#define _FS_SEG_DIR_FORMAT      "/%s/%04x/"
+#define _FS_SLIST_FORMAT        "/%s/%04x/%s.slist"
+#define _FS_TBCHAIN_FORMAT      "/%s/%04x/%s.tbchain"
+#define _FS_TLIST_ALL_FORMAT    "/%s/%04x/m/*.tlist"
+#define _FS_TLIST_DIRD_FORMAT   "/%s/%04x/m/%c%c/%c%c"
+#define _FS_TLIST_DIR_FORMAT    "/%s/%04x/m/%c%c/%c%c/%s.tlist"
+#define _FS_TLIST_FORMAT        "/%s/%04x/m/%016llx.tlist"
+#define _FS_TREE_FORMAT         "/%s/%04x/%s.tree"
+
+#endif

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -15,11 +15,11 @@ datatypestest_LDADD = lib4sintl.a @GLIB_LIBS@
 hashtest_SOURCES = hashtest.c
 hashtest_LDADD = lib4sintl.a @GLIB_LIBS@
 
-lib4sintl_a_SOURCES = 4s-common.c 4s-client.c 4s-server.c 4s-mdns.c datatypes.c error.c umac.c rijndael-alg-fst.c md5.c hash.c ../admin/admin_common.c ../admin/admin_protocol.c ../admin/admin_frontend.c  bit_arr.c
+lib4sintl_a_SOURCES = 4s-common.c 4s-store-root.c 4s-client.c 4s-server.c 4s-mdns.c datatypes.c error.c umac.c rijndael-alg-fst.c md5.c hash.c ../admin/admin_common.c ../admin/admin_protocol.c ../admin/admin_frontend.c  bit_arr.c
 
 libsort_a_SOURCES = msort.c qsort.c
 
 lib_LTLIBRARIES = lib4store.la
-lib4store_la_SOURCES = 4s-common.c 4s-client.c 4s-mdns.c datatypes.c error.c umac.c rijndael-alg-fst.c md5.c hash.c  bit_arr.c
+lib4store_la_SOURCES = 4s-common.c 4s-store-root.c 4s-client.c 4s-mdns.c datatypes.c error.c umac.c rijndael-alg-fst.c md5.c hash.c  bit_arr.c
 lib4store_la_CFLAGS = $(AM_CFLAGS)
 lib4store_la_LIBADD = @GLIB_LIBS@

--- a/src/common/params.h.in
+++ b/src/common/params.h.in
@@ -42,27 +42,8 @@
 /* enables profiling of write() times in import clients */
 #define FS_PROFILE_WRITE
 
-#define FS_STORE_ROOT "@FS_STORE_ROOT@"
-#define FS_KB_DIR     FS_STORE_ROOT "/%s/"
-#define FS_MD_FILE    FS_STORE_ROOT "/%s/metadata.nt"
-#define FS_RI_FILE    FS_STORE_ROOT "/%s/runtime.info"
-#define FS_SEG_DIR    FS_STORE_ROOT "/%s/%04x/"
-#define FS_FILE_LOCK  FS_STORE_ROOT "/%s/%04x/%s.lock"
-#define FS_LEX        FS_STORE_ROOT "/%s/%04x/lex.dat"
-#define FS_CHAIN      FS_STORE_ROOT "/%s/%04x/%s.chain"
-#define FS_TREE       FS_STORE_ROOT "/%s/%04x/%s.tree"
-#define FS_LIST       FS_STORE_ROOT "/%s/%04x/%s.list"
-#define FS_QLIST      FS_STORE_ROOT "/%s/%04x/%s.qlist"
-#define FS_TLIST      FS_STORE_ROOT "/%s/%04x/m/%016llx.tlist"
-#define FS_TLIST_ALL  FS_STORE_ROOT "/%s/%04x/m/*.tlist"
-#define FS_TLIST_DIR  FS_STORE_ROOT "/%s/%04x/m/%c%c/%c%c/%s.tlist"
-#define FS_TLIST_DIRD FS_STORE_ROOT "/%s/%04x/m/%c%c/%c%c"
-#define FS_SLIST      FS_STORE_ROOT "/%s/%04x/%s.slist"
-#define FS_RHASH      FS_STORE_ROOT "/%s/%04x/%s.rhash"
-#define FS_MHASH      FS_STORE_ROOT "/%s/%04x/%s.mhash"
-#define FS_PTREE      FS_STORE_ROOT "/%s/%04x/p%c-%016llx.ptree"
-#define FS_PTABLE     FS_STORE_ROOT "/%s/%04x/%s.ptable"
-#define FS_TBCHAIN    FS_STORE_ROOT "/%s/%04x/%s.tbchain"
+#define FS_DEFAULT_STORE_ROOT "@FS_DEFAULT_STORE_ROOT@"
+#define FS_STORE_ROOT_ENV_VAR "FS_STORE_ROOT"
 
 #define FS_CONFIG_FILE              "@FS_CONFIG_FILE@"
 

--- a/src/utilities/backend-destroy.c
+++ b/src/utilities/backend-destroy.c
@@ -33,6 +33,7 @@
 #include "../common/4store.h"
 #include "../common/error.h"
 #include "../common/params.h"
+#include "../common/4s-store-root.h"
 
 static int dummy = 0;
 
@@ -112,19 +113,31 @@ int main(int argc, char *argv[])
     char lexf[PATH_MAX + 1];
     lexf[PATH_MAX] = '\0';
     int unlinked = 0, errs = 0;
+    gchar *rm_seg_dir_format = g_strconcat("rm -rf ",
+					   fs_get_seg_dir_format(),
+					   "*",
+					   NULL);
     for (fs_segment segment = 0; segment < FS_MAX_SEGMENTS; ++segment)  {
-        snprintf(lexf, PATH_MAX, "rm -rf " FS_SEG_DIR "*", name, segment);
+        snprintf(lexf, PATH_MAX, rm_seg_dir_format, name, segment);
         system(lexf);
-        snprintf(lexf, PATH_MAX, FS_SEG_DIR, name, segment);
+        snprintf(lexf, PATH_MAX, fs_get_seg_dir_format(), name, segment);
         unlinked += delete_it(lexf, &errs);
     }
-    snprintf(lexf, PATH_MAX, FS_KB_DIR "metadata.nt", name);
+    g_free(rm_seg_dir_format);
+
+    gchar *metadata_nt_format = g_strconcat(fs_get_kb_dir_format(), "metadata.nt", NULL);
+    snprintf(lexf, PATH_MAX, metadata_nt_format, name);
     unlinked += delete_it(lexf, &errs);
-    snprintf(lexf, PATH_MAX, FS_KB_DIR "runtime.info", name);
+    g_free(metadata_nt_format);
+    gchar *runtime_info_format = g_strconcat(fs_get_kb_dir_format(), "runtime.info", NULL);
+    snprintf(lexf, PATH_MAX, runtime_info_format, name);
     unlinked += delete_it(lexf, &errs);
-    snprintf(lexf, PATH_MAX, FS_KB_DIR "backup", name);
+    g_free(runtime_info_format);
+    gchar *backup_format = g_strconcat(fs_get_kb_dir_format(), "backup", NULL);
+    snprintf(lexf, PATH_MAX, backup_format, name);
     unlinked += delete_it(lexf, &errs);
-    snprintf(lexf, PATH_MAX, FS_KB_DIR, name);
+    g_free(backup_format);
+    snprintf(lexf, PATH_MAX, fs_get_kb_dir_format(), name);
     unlinked += delete_it(lexf, &errs);
 
     if (unlinked > 0 && !errs) fs_error(LOG_INFO, "deleted data files for KB %s", name);

--- a/src/utilities/backend-info.c
+++ b/src/utilities/backend-info.c
@@ -28,6 +28,7 @@
 #include "../backend/backend.h"
 #include "../backend/backend-intl.h"
 #include "../common/gnu-options.h"
+#include "../common/4s-store-root.h"
 
 int main(int argc, char *argv[])
 {
@@ -46,9 +47,14 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    char *tmp = g_strdup_printf("du -hs "FS_KB_DIR" | sed 's/.\\/var.*/ disk usage/; s/^/  /'", kbname);
+    gchar *tmp_format = g_strconcat("du -hs ",
+				    fs_get_kb_dir_format(),
+				    " | sed 's/.\\/var.*/ disk usage/; s/^/  /'",
+				    NULL);
+    char *tmp = g_strdup_printf(tmp_format, kbname);
     system(tmp);
     g_free(tmp);
+    g_free(tmp_format);
 
     return 0;
 }

--- a/src/utilities/backend-setup.c
+++ b/src/utilities/backend-setup.c
@@ -37,6 +37,7 @@
 #include "../common/4store.h"
 #include "../common/error.h"
 #include "../common/params.h"
+#include "../common/4s-store-root.h"
 #include "../common/md5.h"
 #include "../backend/backend.h"
 #include "../backend/metadata.h"
@@ -197,7 +198,7 @@ void create_dir(kbconfig *config)
     char *tmp;
 
     LOG(1, "Creating data directory");
-    tmp = g_strdup_printf("%s/%s", FS_STORE_ROOT, config->name);
+    tmp = g_strdup_printf("%s/%s", fs_get_store_root(), config->name);
     if (mkdir(tmp, 0755)) {
 	if (errno != EEXIST) {
 	    fprintf(stderr, "Failed to create store directory '%s': %s\n", 
@@ -210,7 +211,7 @@ void create_dir(kbconfig *config)
     LOG(1, "Create segment directories");
     for (int i=0; i<config->segments; i++) {
 	if (!uses_segment(config, i)) continue;
-	tmp = g_strdup_printf("%s/%s/%04x", FS_STORE_ROOT, config->name, i);
+	tmp = g_strdup_printf("%s/%s/%04x", fs_get_store_root(), config->name, i);
 	if (mkdir(tmp, 0755)) {
 	    if (errno != EEXIST) {
 		fprintf(stderr, "Failed to create store directory '%s': %s\n", 
@@ -228,7 +229,7 @@ void create_dir(kbconfig *config)
 	fs_backend_cleanup_files(be);
 	fs_backend_close_files(be, i);
 	/* create directories for model indexes */
-	tmp = g_strdup_printf("%s/%s/%04x/m", FS_STORE_ROOT,
+	tmp = g_strdup_printf("%s/%s/%04x/m", fs_get_store_root(),
 			      config->name, i);
 	mkdir(tmp, 0755);
 	g_free(tmp);
@@ -241,7 +242,7 @@ void erase_db(kbconfig *config)
     for (int i=0; i < config->segments; i++) {
         if (!uses_segment(config, i)) continue;
 	// TODO cleaner delete method, but this is only an admin operation
-        char *command = g_strdup_printf("rm -rf %s/%s/", FS_STORE_ROOT, config->name);
+        char *command = g_strdup_printf("rm -rf %s/%s/", fs_get_store_root(), config->name);
 	system(command);
 	g_free(command);
     }


### PR DESCRIPTION
I wanted to put up a web application on [OpenShift](http://openshift.com/) with a 4store database behind it. But on OpenShift every part of the application (including the database) has to store its data under a certain directory, which has a random name assigned when the app is created, like /home/2793923abec37b37bc3e. So I changed the storage path from being nailed down at build time to having a default set at build time, which can be overridden at run time using an environment variable FS_STORE_ROOT.
