### PR TITLE
back out nonessential changes from 2b2338b

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,13 +20,13 @@ if test "X$PKG_CONFIG" = X; then
 	AC_MSG_ERROR([Cannot find pkg-config, you need this to build])
 fi
 
-AC_ARG_WITH([default_storage_path],
-	[AS_HELP_STRING([--with-default-storage-path=PATH],
-	                [set default directory used to store indexes default=/var/lib/4store])],
+AC_ARG_WITH([storage_path],
+	[AS_HELP_STRING([--with-storage-path=PATH],
+	                [set directory used to store indexes default=/var/lib/4store])],
 	[],
 	[with_storage_path=/var/lib/4store])
-FS_DEFAULT_STORE_ROOT="$with_default_storage_path"
-AC_SUBST(FS_DEFAULT_STORE_ROOT)
+FS_STORE_ROOT="$with_storage_path"
+AC_SUBST(FS_STORE_ROOT)
 
 AC_ARG_WITH([config_file],
 	[AS_HELP_STRING([--with-config-file=PATH],

--- a/src/common/4s-store-root.c
+++ b/src/common/4s-store-root.c
@@ -12,7 +12,7 @@ const gchar * fs_get_store_root(void)
 	if(env_setting) {
 	    _fs_store_root = g_strdup((const gchar *)env_setting);
 	} else {
-	    _fs_store_root = strdup((const gchar *)FS_DEFAULT_STORE_ROOT);
+	    _fs_store_root = strdup((const gchar *)FS_BUILD_TIME_STORE_ROOT);
 	}
     }
     return _fs_store_root;

--- a/src/common/params.h.in
+++ b/src/common/params.h.in
@@ -42,7 +42,7 @@
 /* enables profiling of write() times in import clients */
 #define FS_PROFILE_WRITE
 
-#define FS_DEFAULT_STORE_ROOT "@FS_DEFAULT_STORE_ROOT@"
+#define FS_BUILD_TIME_STORE_ROOT "@FS_STORE_ROOT@"
 #define FS_STORE_ROOT_ENV_VAR "FS_STORE_ROOT"
 
 #define FS_CONFIG_FILE              "@FS_CONFIG_FILE@"


### PR DESCRIPTION
Commit 2b2338b changed the --with-storage-path switch of the configure script
to --with-default-storage-path. That change is not necessary to enable the user
to change the store root at runtime, and breaks some existing installations.
This commit puts the old name back.

Commit 2b2338b changed the FS_STORE_ROOT autoconf substitution variable to
FS_DEFAULT_STORE_ROOT. That change is not really necessary either, and broke
src/utilities/Makefile.am. This commit puts the old name back.
