### PR TITLE
Allow change the HTTP log directory at runtime

### DIFF
--- a/src/common/params.h.in
+++ b/src/common/params.h.in
@@ -48,6 +48,7 @@
 #define FS_CONFIG_FILE              "@FS_CONFIG_FILE@"
 
 #define FS_HTTP_LOG		    "@FS_HTTP_LOG@"
+#define FS_HTTP_LOG_ENV_VAR	    "FS_HTTP_LOG"
 
 #define FS_SKOLEM_PREFIX "@FS_SKOLEM_PREFIX@"
 #define FS_SKOLEMIZE     @FS_SKOLEMIZE@

--- a/src/http/httpd.c
+++ b/src/http/httpd.c
@@ -100,9 +100,24 @@ static void fs_free_global_elements() {
   }
 }
 
+static const gchar * get_http_log_dir(void)
+{
+    static gchar * _fs_log_root = NULL;
+    const char *env_setting;
+    if(NULL == _fs_log_root) {
+        env_setting = getenv(FS_HTTP_LOG_ENV_VAR);
+        if(env_setting) {
+            _fs_log_root = g_strdup((const gchar *)env_setting);
+        } else {
+            _fs_log_root = strdup((const gchar *)FS_HTTP_LOG);
+        }
+    }
+    return _fs_log_root;
+}
+
 static void query_log_open (const char *kb_name)
 {
-  char *filename = g_strdup_printf(FS_HTTP_LOG "/query-%s.log", kb_name);
+  char *filename = g_strdup_printf("%s/query-%s.log", get_http_log_dir(), kb_name);
 
   ql_file= fopen(filename, "a");
   if (ql_file) {


### PR DESCRIPTION
Similar to PR #112, this pull request makes it possible to change the HTTP log directory at runtime using the FS_HTTP_LOG environment variable.