### PR TITLE
use _GNU_SOURCE instead of __USE_MISC

### DIFF
--- a/src/frontend/filter-datatypes.c
+++ b/src/frontend/filter-datatypes.c
@@ -18,11 +18,11 @@
  *  Copyright (C) 2006 Steve Harris for Garlik
  */
 
-#define _XOPEN_SOURCE
+#define _GNU_SOURCE
+
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
-#define __USE_MISC
 #include <time.h>
 
 #include "filter.h"


### PR DESCRIPTION
Defining __USE_MISC directly is forbidden in feature_test_macros(7).

Use _GNU_SOURCE, as other source files do already, which implies
_XOPEN_SOURCE and __USE_MISC.

Please see https://bugs.debian.org/810975#10 for longer explanation.
Thanks!